### PR TITLE
[EasyApiToken]: Add factory for EasyApiTokenDecoder objects

### DIFF
--- a/packages/EasyApiToken/src/Exceptions/AbstractEasyApiTokenFactoryException.php
+++ b/packages/EasyApiToken/src/Exceptions/AbstractEasyApiTokenFactoryException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Exceptions;
+
+use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenExceptionInterface;
+
+abstract class AbstractEasyApiTokenFactoryException extends \Exception implements EasyApiTokenExceptionInterface
+{
+    // No body needed.
+}
+
+\class_alias(
+    AbstractEasyApiTokenException::class,
+    'StepTheFkUp\EasyApiToken\Exceptions\AbstractEasyApiTokenException',
+    false
+);

--- a/packages/EasyApiToken/src/Exceptions/AbstractEasyApiTokenFactoryException.php
+++ b/packages/EasyApiToken/src/Exceptions/AbstractEasyApiTokenFactoryException.php
@@ -11,7 +11,7 @@ abstract class AbstractEasyApiTokenFactoryException extends \Exception implement
 }
 
 \class_alias(
-    AbstractEasyApiTokenException::class,
-    'StepTheFkUp\EasyApiToken\Exceptions\AbstractEasyApiTokenException',
+    AbstractEasyApiTokenFactoryException::class,
+    'StepTheFkUp\EasyApiToken\Exceptions\AbstractEasyApiTokenFactoryException',
     false
 );

--- a/packages/EasyApiToken/src/Exceptions/InvalidConfigurationException.php
+++ b/packages/EasyApiToken/src/Exceptions/InvalidConfigurationException.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Exceptions;
+
+final class InvalidConfigurationException extends AbstractEasyApiTokenException
+{
+    // No body needed.
+}
+
+\class_alias(
+    InvalidConfigurationException::class,
+    'StepTheFkUp\EasyApiToken\Exceptions\InvalidConfigurationException',
+    false
+);

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -58,12 +58,21 @@ class EasyApiDecoderFactory
                 return new BasicAuthDecoder();
             case 'user-apikey':
                 return new ApiKeyAsBasicAuthUsernameDecoder();
+            case 'chain':
+                return $this->createChain($configKey, $this->config[$configKey]);
+        }
+
+        if (\array_key_exists('options', $this->config[$configKey]) === false) {
+            throw new InvalidConfigurationException(\sprintf(
+                'Missing options array for EasyApiToken decoder: %s.', $configKey
+            ));
+        }
+
+        switch ($decoderType) {
             case 'jwt-header':
                 return $this->createJwtHeaderDecoder($this->config[$configKey]);
             case 'jwt-param':
                 return $this->createJwtParamDecoder($this->config[$configKey]);
-            case 'chain':
-                return $this->createChain($configKey, $this->config[$configKey]);
         }
         throw new InvalidConfigurationException(
             \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -150,6 +150,8 @@ class EasyApiDecoderFactory
      * @param array $options List of options to use to create Driver.
      *
      * @return \LoyaltyCorp\EasyApiToken\External\Interfaces\JwtDriverInterface
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
     private function createJwtDriver($driver, $options): JwtDriverInterface
     {
@@ -159,7 +161,9 @@ class EasyApiDecoderFactory
             case 'firebase':
                 return $this->createFirebaseDriver($options);
         }
-        //todo add exception handler here
+        throw new InvalidConfigurationException(\sprintf(
+            'Invalid JWT decoder driver: %s.', $driver
+        ));
     }
 
     /**

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -5,6 +5,7 @@ namespace LoyaltyCorp\EasyApiToken\Factories;
 
 use LoyaltyCorp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Decoders\ChainReturnFirstTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenInQueryDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
@@ -61,10 +62,32 @@ class EasyApiDecoderFactory
                 return $this->createJwtHeaderDecoder($this->config[$configKey]);
             case 'jwt-param':
                 return $this->createJwtParamDecoder($this->config[$configKey]);
+            case 'chain':
+                return $this->createChain($this->config[$configKey]);
         }
         throw new InvalidConfigurationException(
             \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)
         );
+    }
+
+    /**
+     * Build a chain Decoder.
+     *
+     * @param array $config Configuration options for the chain driver. Should have a single item named 'list'.
+     *
+     * @return \LoyaltyCorp\EasyApiToken\Decoders\ChainReturnFirstTokenDecoder
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidArgumentException
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    private function createChain($config)
+    {
+        $driverKeys = $config['list']; // todo - handle this missing. chain.
+
+        $list = [];
+        foreach ($driverKeys as $key) {
+            $list[] = $this->build($key);
+        }
+        return new ChainReturnFirstTokenDecoder($list);
     }
 
     /**

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -63,6 +63,16 @@ class EasyApiDecoderFactory
     }
 
     private function createJwtHeaderDecoder(array $configuration) {
-        return new JwtTokenDecoder(new JwtEasyApiTokenFactory( new Auth0JwtDriver([], [], '')));
+        $driverConfiguration = $configuration['driver']; // todo test this missing
+        $options = $configuration['options']; // todo stuff to validate required fields
+
+        $driver = new Auth0JwtDriver(
+            $options['valid_audiences'],
+            $options['authorized_iss'],
+            $options['private_key'],
+            $options['audience_for_encode'] ?? null,
+            $options['allowed_algos'] ?? null
+        );
+        return new JwtTokenDecoder(new JwtEasyApiTokenFactory($driver));
     }
 }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -55,10 +55,14 @@ class EasyApiDecoderFactory
             case 'user-apikey':
                 return new ApiKeyAsBasicAuthUsernameDecoder();
             case 'jwt-header':
-                return new JwtTokenDecoder(new JwtEasyApiTokenFactory( new Auth0JwtDriver([], [], '')));
+                return $this->createJwtHeaderDecoder($this->config[$configKey]);
         }
         throw new InvalidConfigurationException(
             \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)
         );
+    }
+
+    private function createJwtHeaderDecoder(array $configuration) {
+        return new JwtTokenDecoder(new JwtEasyApiTokenFactory( new Auth0JwtDriver([], [], '')));
     }
 }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -63,7 +63,7 @@ class EasyApiDecoderFactory
             case 'jwt-param':
                 return $this->createJwtParamDecoder($this->config[$configKey]);
             case 'chain':
-                return $this->createChain($this->config[$configKey]);
+                return $this->createChain($configKey, $this->config[$configKey]);
         }
         throw new InvalidConfigurationException(
             \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)
@@ -73,15 +73,22 @@ class EasyApiDecoderFactory
     /**
      * Build a chain Decoder.
      *
+     * @param string $name The name of this chain driver being requested.
      * @param array $config Configuration options for the chain driver. Should have a single item named 'list'.
      *
      * @return \LoyaltyCorp\EasyApiToken\Decoders\ChainReturnFirstTokenDecoder
+     *
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidArgumentException
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
-    private function createChain($config)
+    private function createChain($name, $config): ChainReturnFirstTokenDecoder
     {
-        $driverKeys = $config['list']; // todo - handle this missing. chain.
+        if (\array_key_exists('list', $config) === false) {
+            throw new InvalidConfigurationException(\sprintf(
+                'EasyApiToken decoder: %s is missing a required list option.', $name
+            ));
+        }
+        $driverKeys = $config['list'];
 
         $list = [];
         foreach ($driverKeys as $key) {

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -24,14 +24,23 @@ class EasyApiDecoderFactory
     }
 
     /**
+     * Build a named TokenFactory.
+     *
+     * @param string $configKey Key of configuration found in the configuration.
+     *
      * @return \LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface
      *
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
-    public function build(): EasyApiTokenDecoderInterface
+    public function build(string $configKey): EasyApiTokenDecoderInterface
     {
         if (\count($this->config) === 0) {
             throw new InvalidConfigurationException('Could not find a valid configuration.');
+        }
+        if (\array_key_exists($configKey, $this->config) === false) {
+            throw new InvalidConfigurationException(
+                \sprintf('Could not find EasyApiConfiguration for key: %s.', $configKey)
+            );
         }
         return new BasicAuthDecoder();
     }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -5,8 +5,11 @@ namespace LoyaltyCorp\EasyApiToken\Factories;
 
 use LoyaltyCorp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
+use LoyaltyCorp\EasyApiToken\External\Auth0JwtDriver;
 use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
+use LoyaltyCorp\EasyApiToken\Tokens\Factories\JwtEasyApiTokenFactory;
 
 class EasyApiDecoderFactory
 {
@@ -51,6 +54,8 @@ class EasyApiDecoderFactory
                 return new BasicAuthDecoder();
             case 'user-apikey':
                 return new ApiKeyAsBasicAuthUsernameDecoder();
+            case 'jwt-header':
+                return new JwtTokenDecoder(new JwtEasyApiTokenFactory( new Auth0JwtDriver([], [], '')));
         }
         throw new InvalidConfigurationException(
             \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Factories;
+
+use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
+use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
+
+class EasyApiDecoderFactory
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * EasyApiDecoderFactory constructor.
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return \LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    public function build(): EasyApiTokenDecoderInterface
+    {
+        if (\count($this->config) === 0) {
+            throw new InvalidConfigurationException('Could not find a valid configuration.');
+        }
+        return new BasicAuthDecoder();
+    }
+}

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -38,6 +38,7 @@ class EasyApiDecoderFactory
      *
      * @return \LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface
      *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidArgumentException
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
     public function build(string $configKey): EasyApiTokenDecoderInterface
@@ -117,8 +118,10 @@ class EasyApiDecoderFactory
      * @param array $configuration Options for building decoder.
      *
      * @return \LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
-    private function createJwtHeaderDecoder(array $configuration)
+    private function createJwtHeaderDecoder(array $configuration): JwtTokenDecoder
     {
         $driverName = $configuration['driver'];
         $options = $configuration['options'];
@@ -133,8 +136,10 @@ class EasyApiDecoderFactory
      * @param array $configuration Options for building decoder.
      *
      * @return \LoyaltyCorp\EasyApiToken\Decoders\JwtTokenInQueryDecoder
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
-    private function createJwtParamDecoder(array $configuration)
+    private function createJwtParamDecoder(array $configuration): JwtTokenInQueryDecoder
     {
         $driverName = $configuration['driver'];
         $options = $configuration['options'];

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\EasyApiToken\Factories;
 
+use LoyaltyCorp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
 use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
@@ -42,6 +43,14 @@ class EasyApiDecoderFactory
                 \sprintf('Could not find EasyApiConfiguration for key: %s.', $configKey)
             );
         }
-        return new BasicAuthDecoder();
+        // todo next check if driver exists
+        $driver = $this->config[$configKey]['driver'];
+
+        switch ($driver) {
+            case 'basic':
+                return new BasicAuthDecoder();
+            case 'user-apikey':
+                return new ApiKeyAsBasicAuthUsernameDecoder();
+        }
     }
 }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -15,6 +15,9 @@ use LoyaltyCorp\EasyApiToken\External\Interfaces\JwtDriverInterface;
 use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
 use LoyaltyCorp\EasyApiToken\Tokens\Factories\JwtEasyApiTokenFactory;
 
+/**
+ * Build an EasyApiDecoder from a configuration file.
+ */
 class EasyApiDecoderFactory
 {
     /**

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -40,20 +40,20 @@ class EasyApiDecoderFactory
         }
         if (\array_key_exists($configKey, $this->config) === false) {
             throw new InvalidConfigurationException(
-                \sprintf('Could not find EasyApiConfiguration for key: %s.', $configKey)
+                \sprintf('Could not find EasyApiToken for key: %s.', $configKey)
             );
         }
 
-        $driver = $this->config[$configKey]['driver'] ?? '';
+        $decoderType = $this->config[$configKey]['type'] ?? '';
 
-        switch ($driver) {
+        switch ($decoderType) {
             case 'basic':
                 return new BasicAuthDecoder();
             case 'user-apikey':
                 return new ApiKeyAsBasicAuthUsernameDecoder();
         }
         throw new InvalidConfigurationException(
-            \sprintf('Invalid EasyApiToken driver: %s configured for key: %s.', $driver,$configKey)
+            \sprintf('Invalid EasyApiToken decoder type: %s configured for key: %s.', $decoderType, $configKey)
         );
     }
 }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -43,8 +43,8 @@ class EasyApiDecoderFactory
                 \sprintf('Could not find EasyApiConfiguration for key: %s.', $configKey)
             );
         }
-        // todo next check if driver exists
-        $driver = $this->config[$configKey]['driver'];
+
+        $driver = $this->config[$configKey]['driver'] ?? '';
 
         switch ($driver) {
             case 'basic':
@@ -52,5 +52,8 @@ class EasyApiDecoderFactory
             case 'user-apikey':
                 return new ApiKeyAsBasicAuthUsernameDecoder();
         }
+        throw new InvalidConfigurationException(
+            \sprintf('Invalid EasyApiToken driver: %s configured for key: %s.', $driver,$configKey)
+        );
     }
 }

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -67,6 +67,11 @@ class EasyApiDecoderFactory
                 'Missing options array for EasyApiToken decoder: %s.', $configKey
             ));
         }
+        if (\array_key_exists('driver', $this->config[$configKey]) === false) {
+            throw new InvalidConfigurationException(\sprintf(
+                'EasyApiToken decoder: %s is missing a driver key.', $configKey
+            ));
+        }
 
         switch ($decoderType) {
             case 'jwt-header':

--- a/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiDecoderFactory.php
@@ -67,7 +67,15 @@ class EasyApiDecoderFactory
         );
     }
 
-    private function createJwtHeaderDecoder(array $configuration) {
+    /**
+     * Build a JWT parameter decoder.
+     *
+     * @param array $configuration Options for building decoder.
+     *
+     * @return \LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder
+     */
+    private function createJwtHeaderDecoder(array $configuration)
+    {
         $driverName = $configuration['driver'];
         $options = $configuration['options'];
 
@@ -75,7 +83,15 @@ class EasyApiDecoderFactory
         return new JwtTokenDecoder(new JwtEasyApiTokenFactory($driver));
     }
 
-    private function createJwtParamDecoder(array $configuration) {
+    /**
+     * Build a JWT request decoder.
+     *
+     * @param array $configuration Options for building decoder.
+     *
+     * @return \LoyaltyCorp\EasyApiToken\Decoders\JwtTokenInQueryDecoder
+     */
+    private function createJwtParamDecoder(array $configuration)
+    {
         $driverName = $configuration['driver'];
         $options = $configuration['options'];
 
@@ -83,6 +99,14 @@ class EasyApiDecoderFactory
         return new JwtTokenInQueryDecoder(new JwtEasyApiTokenFactory($driver), $options['param']);
     }
 
+    /**
+     * Build a JWT driver.
+     *
+     * @param string $driver Driver to build, must be one of 'auth0' or 'firebase'.
+     * @param array $options List of options to use to create Driver.
+     *
+     * @return \LoyaltyCorp\EasyApiToken\External\Interfaces\JwtDriverInterface
+     */
     private function createJwtDriver($driver, $options): JwtDriverInterface
     {
         switch ($driver) {
@@ -95,10 +119,13 @@ class EasyApiDecoderFactory
     }
 
     /**
-     * @param $options
+     * Build a Auth09 JWT Driver.
+     *
+     * @param mixed[] $options List of options to pass to Auth0JwtDriver. Keys match constructor parameters.
+     *
      * @return \LoyaltyCorp\EasyApiToken\External\Auth0JwtDriver
      */
-    private function createAuth0Driver($options): \LoyaltyCorp\EasyApiToken\External\Auth0JwtDriver
+    private function createAuth0Driver($options): Auth0JwtDriver
     {
         $driver = new Auth0JwtDriver(
             $options['valid_audiences'],
@@ -111,10 +138,13 @@ class EasyApiDecoderFactory
     }
 
     /**
-     * @param $options
+     * Build a Firebase JWT Driver.
+     *
+     * @param mixed[] $options List of options to pass to FirebaseJwtDriver. Keys match constructor parameters.
+     *
      * @return \LoyaltyCorp\EasyApiToken\External\FirebaseJwtDriver
      */
-    private function createFirebaseDriver($options): \LoyaltyCorp\EasyApiToken\External\FirebaseJwtDriver
+    private function createFirebaseDriver($options): FirebaseJwtDriver
     {
         $driver = new FirebaseJwtDriver(
             $options['algo'],

--- a/packages/EasyApiToken/src/Factories/EasyApiTokenDecoderFactory.php
+++ b/packages/EasyApiToken/src/Factories/EasyApiTokenDecoderFactory.php
@@ -18,7 +18,7 @@ use LoyaltyCorp\EasyApiToken\Tokens\Factories\JwtEasyApiTokenFactory;
 /**
  * Build an EasyApiDecoder from a configuration file.
  */
-class EasyApiDecoderFactory
+class EasyApiTokenDecoderFactory
 {
     /**
      * @var array
@@ -26,7 +26,7 @@ class EasyApiDecoderFactory
     private $config;
 
     /**
-     * EasyApiDecoderFactory constructor.
+     * EasyApiTokenDecoderFactory constructor.
      * @param array $config
      */
     public function __construct(array $config)

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -25,9 +25,9 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
 
     public function testBasicAuthCreation(): void
     {
-        $factory = new EasyApiDecoderFactory(['basic' => []]);
+        $factory = new EasyApiDecoderFactory(['something' => ['driver' => 'basic']]);
 
-        $actual = $factory->build();
+        $actual = $factory->build('something');
 
         $this->assertInstanceOf(BasicAuthDecoder::class, $actual);
     }

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -43,18 +43,18 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
     }
 
     /**
-     * Test that a chain driver is configured on request.
+     * Test that an error is thrown when a non-existent key is requested.
      *
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
-    public function test(): void
+    public function testNoSuchKey(): void
     {
         $factory = new EasyApiDecoderFactory(['onething' => ['driver' => 'basic']]);
 
-        $factory->build('some_other_thing');
-
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Could not find EasyApiConfiguration for key: some_other_thing.');
+
+        $factory->build('some_other_thing');
     }
 }
 

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -7,6 +7,7 @@ use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
 use LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory;
 use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
+use StepTheFkUp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 
 /**
  * @covers \LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory
@@ -55,6 +56,20 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $this->expectExceptionMessage('Could not find EasyApiConfiguration for key: some_other_thing.');
 
         $factory->build('some_other_thing');
+    }
+
+    /**
+     * Test that an ApiKeyAsBasicAuthUsernameDecoder is created when requested.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    public function testApiKeyDriver(): void
+    {
+        $factory = new EasyApiDecoderFactory(['apiconfig' => ['driver' => 'user-apikey']]);
+
+        $actual = $factory->build('apiconfig');
+
+        $this->assertInstanceOf(ApiKeyAsBasicAuthUsernameDecoder::class, $actual);
     }
 }
 

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace LoyaltyCorp\EasyApiToken\Tests\Factories;
 
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Decoders\ChainReturnFirstTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenInQueryDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
@@ -197,6 +198,35 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
     }
 
     /**
+     * @return iterable
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidArgumentException
+     */
+    public function getChainBuilds(): iterable
+    {
+        $config = [
+            'chain-key' => [
+                'type' => 'chain',
+                'list' => [
+                    'api',
+                    'pass'
+                ],
+            ],
+            'api' => ['type' => 'user-apikey'],
+            'pass' => ['type' => 'basic']
+        ];
+
+        yield 'Build API Chain' => [
+            $config,
+            'chain-key',
+            new ChainReturnFirstTokenDecoder([
+                new ApiKeyAsBasicAuthUsernameDecoder(),
+                new BasicAuthDecoder()
+            ])
+        ];
+    }
+
+    /**
      * Test that the requested object graph is built as expected.
      *
      * @param array $config
@@ -209,6 +239,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      *
      * @dataProvider getSimpleBuilds
      * @dataProvider getJwtBuilds
+     * @dataProvider getChainBuilds
      */
     public function testBuild(array $config, string $key, EasyApiTokenDecoderInterface $expected): void
     {

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -53,13 +53,13 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $factory = new EasyApiDecoderFactory(['onething' => ['type' => 'basic']]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Could not find EasyApiConfiguration for key: some_other_thing.');
+        $this->expectExceptionMessage('Could not find EasyApiToken for key: some_other_thing.');
 
         $factory->build('some_other_thing');
     }
 
     /**
-     * Test that an error is thrown when a non-existent driver is configured.
+     * Test that an error is thrown when a non-existent decoder type is configured.
      *
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
      */
@@ -68,7 +68,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $factory = new EasyApiDecoderFactory(['xxx' => ['type' => 'yyy']]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Invalid EasyApiToken driver: yyy configured for key: xxx.');
+        $this->expectExceptionMessage('Invalid EasyApiToken decoder type: yyy configured for key: xxx.');
 
         $factory->build('xxx');
     }

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -10,14 +10,14 @@ use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenInQueryDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
 use LoyaltyCorp\EasyApiToken\External\Auth0JwtDriver;
 use LoyaltyCorp\EasyApiToken\External\FirebaseJwtDriver;
-use LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory;
+use LoyaltyCorp\EasyApiToken\Factories\EasyApiTokenDecoderFactory;
 use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
 use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
 use LoyaltyCorp\EasyApiToken\Tokens\Factories\JwtEasyApiTokenFactory;
 use StepTheFkUp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 
 /**
- * @covers \LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory
+ * @covers \LoyaltyCorp\EasyApiToken\Factories\EasyApiTokenDecoderFactory
  */
 final class EasyApiDecoderFactoryTest extends AbstractTestCase
 {
@@ -248,7 +248,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testBuild(array $config, string $key, EasyApiTokenDecoderInterface $expected): void
     {
-        $factory = new EasyApiDecoderFactory($config);
+        $factory = new EasyApiTokenDecoderFactory($config);
 
         $actual = $factory->build($key);
 
@@ -268,7 +268,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testInvalidConfigurationErrors(array $config, string $key, string $expectedError): void
     {
-        $factory = new EasyApiDecoderFactory($config);
+        $factory = new EasyApiTokenDecoderFactory($config);
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage($expectedError);

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Tests\Factories;
+
+use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
+use LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory;
+use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
+
+/**
+ * @covers \LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory
+ */
+final class EasyApiDecoderFactoryTest extends AbstractTestCase
+{
+    public function testNullCreation(): void
+    {
+        $factory = new EasyApiDecoderFactory([]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Could not find a valid configuration.');
+
+        $factory->build();
+    }
+
+    public function testBasicAuthCreation(): void
+    {
+        $factory = new EasyApiDecoderFactory(['basic' => []]);
+
+        $actual = $factory->build();
+
+        $this->assertInstanceOf(BasicAuthDecoder::class, $actual);
+    }
+}
+
+\class_alias(
+    EasyApiDecoderFactoryTest::class,
+    'StepTheFkUp\EasyApiToken\Tests\Factories\EasyApiDecoderFactoryTest',
+    false
+);

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -41,6 +41,21 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
 
         $this->assertInstanceOf(BasicAuthDecoder::class, $actual);
     }
+
+    /**
+     * Test that a chain driver is configured on request.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    public function test(): void
+    {
+        $factory = new EasyApiDecoderFactory(['onething' => ['driver' => 'basic']]);
+
+        $factory->build('some_other_thing');
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Could not find EasyApiConfiguration for key: some_other_thing.');
+    }
 }
 
 \class_alias(

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -59,6 +59,21 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
     }
 
     /**
+     * Test that an error is thrown when a non-existent driver is configured.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    public function testInvalidDriver(): void
+    {
+        $factory = new EasyApiDecoderFactory(['xxx' => ['driver' => 'yyy']]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid EasyApiToken driver: yyy configured for key: xxx.');
+
+        $factory->build('xxx');
+    }
+
+    /**
      * Test that an ApiKeyAsBasicAuthUsernameDecoder is created when requested.
      *
      * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -45,6 +45,12 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
             'xxx',
             'Invalid EasyApiToken decoder type: yyy configured for key: xxx.'
         ];
+
+        yield 'Expect chain driver with no list to return error.' => [
+            ['chain-thing' => ['type' => 'chain']],
+            'chain-thing',
+            'EasyApiToken decoder: chain-thing is missing a required list option.'
+        ];
     }
 
     public function getSimpleBuilds(): iterable

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -36,7 +36,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testBasicAuthCreation(): void
     {
-        $factory = new EasyApiDecoderFactory(['something' => ['driver' => 'basic']]);
+        $factory = new EasyApiDecoderFactory(['something' => ['type' => 'basic']]);
 
         $actual = $factory->build('something');
 
@@ -50,7 +50,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testNoSuchKey(): void
     {
-        $factory = new EasyApiDecoderFactory(['onething' => ['driver' => 'basic']]);
+        $factory = new EasyApiDecoderFactory(['onething' => ['type' => 'basic']]);
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Could not find EasyApiConfiguration for key: some_other_thing.');
@@ -65,7 +65,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testInvalidDriver(): void
     {
-        $factory = new EasyApiDecoderFactory(['xxx' => ['driver' => 'yyy']]);
+        $factory = new EasyApiDecoderFactory(['xxx' => ['type' => 'yyy']]);
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Invalid EasyApiToken driver: yyy configured for key: xxx.');
@@ -80,7 +80,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
      */
     public function testApiKeyDriver(): void
     {
-        $factory = new EasyApiDecoderFactory(['apiconfig' => ['driver' => 'user-apikey']]);
+        $factory = new EasyApiDecoderFactory(['apiconfig' => ['type' => 'user-apikey']]);
 
         $actual = $factory->build('apiconfig');
 

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -41,7 +41,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         ];
 
         yield 'Test that an error is thrown when a non-existent decoder type is configured.' => [
-            ['xxx' => ['type' => 'yyy', 'options' => []]],
+            ['xxx' => ['type' => 'yyy', 'driver' => 'auth0', 'options' => []]],
             'xxx',
             'Invalid EasyApiToken decoder type: yyy configured for key: xxx.'
         ];

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace LoyaltyCorp\EasyApiToken\Tests\Factories;
 
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
+use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
 use LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory;
 use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
@@ -85,6 +86,31 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $actual = $factory->build('apiconfig');
 
         $this->assertInstanceOf(ApiKeyAsBasicAuthUsernameDecoder::class, $actual);
+    }
+
+    /**
+     * Test that an JwtTokenDecoder is created when requested.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
+    public function testJwtWithAuth0Configuration(): void
+    {
+        $factory = new EasyApiDecoderFactory([
+            'jwt' => [
+                'type' => 'jwt-header',
+                'driver' => 'auth0',
+                'options' => [
+                    'valid_audiences' => ['id1', 'id2'],
+                    'authorized_iss' => ['xyz.auth0', 'abc.goog'],
+                    'private_key' => 'someprivatekeystring',
+                    'allowed_algos' => ['HS256', 'RS256']
+                ]
+            ]
+        ]);
+
+        $actual = $factory->build('jwt');
+
+        $this->assertInstanceOf(JwtTokenDecoder::class, $actual);
     }
 }
 

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -6,7 +6,9 @@ namespace LoyaltyCorp\EasyApiToken\Tests\Factories;
 use LoyaltyCorp\EasyApiToken\Decoders\BasicAuthDecoder;
 use LoyaltyCorp\EasyApiToken\Decoders\JwtTokenDecoder;
 use LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException;
+use LoyaltyCorp\EasyApiToken\External\Auth0JwtDriver;
 use LoyaltyCorp\EasyApiToken\Factories\EasyApiDecoderFactory;
+use LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface;
 use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
 use StepTheFkUp\EasyApiToken\Decoders\ApiKeyAsBasicAuthUsernameDecoder;
 
@@ -111,6 +113,51 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $actual = $factory->build('jwt');
 
         $this->assertInstanceOf(JwtTokenDecoder::class, $actual);
+        $this->assertJwtDriverConfiguration(Auth0JwtDriver::class,
+            [
+                    'allowedAlgos' => ['HS256', 'RS256'],
+                    'audienceForEncode' => 'id1',
+                    'authorizedIss' => ['xyz.auth0', 'abc.goog'],
+                    'privateKey' => 'someprivatekeystring',
+                    'validAudiences' => ['id1', 'id2']
+            ],
+            $actual
+        );
+    }
+
+    /**
+     * Assert that JWT drivers are built correctly.
+     *
+     * @param string $class Expected JWT Driver class.
+     * @param array $properties List of properties that should be set on the JWT Driver class.
+     * @param \LoyaltyCorp\EasyApiToken\Interfaces\EasyApiTokenDecoderInterface $actual Implementation to test.
+     *
+     * @throws \ReflectionException
+     */
+    private function assertJwtDriverConfiguration(
+        string $class,
+        array $properties,
+        EasyApiTokenDecoderInterface $actual
+    ): void {
+        $decoderReflection = new \ReflectionClass($actual);
+        $decoderTokenProperty = $decoderReflection->getProperty('jwtApiTokenFactory');
+        $decoderTokenProperty->setAccessible(true);
+        $tokenFactory = $decoderTokenProperty->getValue($actual);
+
+        $tokenFactoryReflection = new \ReflectionClass($tokenFactory);
+        $tokenFactoryDriverProperty = $tokenFactoryReflection->getProperty('jwtDriver');
+        $tokenFactoryDriverProperty->setAccessible(true);
+        $jwtDriver = $tokenFactoryDriverProperty->getValue($tokenFactory);
+
+        $this->assertInstanceOf($class, $jwtDriver);
+
+        $jwtDriverReflection = new \ReflectionClass($jwtDriver);
+        foreach ($properties as $property => $expectedValue) {
+            $jwtDriverProperty = $jwtDriverReflection->getProperty($property);
+            $jwtDriverProperty->setAccessible(true);
+            $actualValue = $jwtDriverProperty->getValue($jwtDriver);
+            $this->assertSame($expectedValue, $actualValue, "Failed on {$property}");
+        }
     }
 }
 

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -41,7 +41,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         ];
 
         yield 'Test that an error is thrown when a non-existent decoder type is configured.' => [
-            ['xxx' => ['type' => 'yyy']],
+            ['xxx' => ['type' => 'yyy', 'options' => []]],
             'xxx',
             'Invalid EasyApiToken decoder type: yyy configured for key: xxx.'
         ];
@@ -59,13 +59,13 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         ];
 
         yield 'Expect error for invalid jwt driver.' => [
-            ['foobar' => ['type' => 'jwt-header', 'driver' => 'GOOGLE']],
+            ['foobar' => ['type' => 'jwt-header', 'driver' => 'GOOGLE', 'options' => []]],
             'foobar',
             'Invalid JWT decoder driver: GOOGLE configured for EasyApiToken decoder: foobar.'
         ];
 
         yield 'Expect error for missing jwt driver' => [
-            ['something' => ['type' => 'jwt-header']],
+            ['something' => ['type' => 'jwt-header', 'options' => []]],
             'something',
             'EasyApiToken decoder: something is missing a driver key.'
         ];

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -51,6 +51,18 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
             'chain-thing',
             'EasyApiToken decoder: chain-thing is missing a required list option.'
         ];
+
+        yield 'Expect error for invalid jwt driver.' => [
+            ['foobar' => ['type' => 'jwt-header', 'driver' => 'GOOGLE']],
+            'foobar',
+            'Invalid JWT decoder driver: GOOGLE configured for EasyApiToken decoder: foobar.'
+        ];
+
+        yield 'Expect error for missing jwt driver' => [
+            ['something' => ['type' => 'jwt-header']],
+            'something',
+            'EasyApiToken decoder: something is missing a driver key.'
+        ];
     }
 
     public function getSimpleBuilds(): iterable

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -13,6 +13,11 @@ use LoyaltyCorp\EasyApiToken\Tests\AbstractTestCase;
  */
 final class EasyApiDecoderFactoryTest extends AbstractTestCase
 {
+    /**
+     * Test that an empty exception throws an error.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
     public function testNullCreation(): void
     {
         $factory = new EasyApiDecoderFactory([]);
@@ -23,6 +28,11 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $factory->build();
     }
 
+    /**
+     * Test that a basic driver is configured on request.
+     *
+     * @throws \LoyaltyCorp\EasyApiToken\Exceptions\InvalidConfigurationException
+     */
     public function testBasicAuthCreation(): void
     {
         $factory = new EasyApiDecoderFactory(['something' => ['driver' => 'basic']]);

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -61,7 +61,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         yield 'Expect error for invalid jwt driver.' => [
             ['foobar' => ['type' => 'jwt-header', 'driver' => 'GOOGLE', 'options' => []]],
             'foobar',
-            'Invalid JWT decoder driver: GOOGLE configured for EasyApiToken decoder: foobar.'
+            'Invalid JWT decoder driver: GOOGLE.'
         ];
 
         yield 'Expect error for missing jwt driver' => [

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -52,6 +52,12 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
             'EasyApiToken decoder: chain-thing is missing a required list option.'
         ];
 
+        yield 'Expect error for missing options supplied for JWT driver.' => [
+            ['rad' => ['type' => 'jwt-header', 'driver' => 'auth0']],
+            'rad',
+            'Missing options array for EasyApiToken decoder: rad.'
+        ];
+
         yield 'Expect error for invalid jwt driver.' => [
             ['foobar' => ['type' => 'jwt-header', 'driver' => 'GOOGLE']],
             'foobar',

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -25,7 +25,7 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Could not find a valid configuration.');
 
-        $factory->build();
+        $factory->build('nothing');
     }
 
     /**

--- a/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
+++ b/packages/EasyApiToken/tests/Factories/EasyApiDecoderFactoryTest.php
@@ -104,6 +104,28 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
                     'private_key' => 'someprivatekeystring',
                     'public_key' => 'somepublickeystring',
                 ]
+            ],
+            'jwt-by-header-firebase' => [
+                'type' => 'jwt-header',
+                'driver' => 'firebase',
+                'options' => [
+                    'algo' => 'HS256',
+                    'allowed_algos' => ['HS256', 'RS256'],
+                    'leeway' => 15,
+                    'private_key' => 'someprivatekeystring',
+                    'public_key' => 'somepublickeystring',
+                ]
+            ],
+            'jwt-by-parameter-auth0' => [
+                'type' => 'jwt-param',
+                'driver' => 'auth0',
+                'options' => [
+                    'allowed_algos' => ['HS256', 'RS256'],
+                    'authorized_iss' => ['xyz.auth0', 'abc.goog'],
+                    'param' => 'authParam',
+                    'private_key' => 'someprivatekeystring',
+                    'valid_audiences' => ['id1', 'id2']
+                ]
             ]
         ];
 
@@ -134,6 +156,39 @@ final class EasyApiDecoderFactoryTest extends AbstractTestCase
                         'someprivatekeystring',
                         ['HS256', 'RS256'],
                         15
+                    )
+                ),
+                'authParam'
+            )
+        ];
+
+        yield 'Jwt Header with Firebase' => [
+            $config,
+            'jwt-by-header-firebase',
+            new JwtTokenDecoder(
+                new JwtEasyApiTokenFactory(
+                    new FirebaseJwtDriver(
+                        'HS256',
+                        'somepublickeystring',
+                        'someprivatekeystring',
+                        ['HS256', 'RS256'],
+                        15
+                    )
+                )
+            )
+        ];
+
+        yield 'Jwt Parameter with Auth0' => [
+            $config,
+            'jwt-by-parameter-auth0',
+            new JwtTokenInQueryDecoder(
+                new JwtEasyApiTokenFactory(
+                    new Auth0JwtDriver(
+                        ['id1', 'id2'],
+                        ['xyz.auth0', 'abc.goog'],
+                        'someprivatekeystring',
+                        'id1',
+                        ['HS256', 'RS256']
                     )
                 ),
                 'authParam'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This adds a factory to build EasyApiToken decoder based on a configuration array.