### PR TITLE
[EasyDocker] Fix nginx conf to listen to port 80 instead of 8080

### DIFF
--- a/packages/EasyDocker/templates/docker/nginx/default.conf.twig
+++ b/packages/EasyDocker/templates/docker/nginx/default.conf.twig
@@ -1,5 +1,5 @@
 server {
-    listen 8080;
+    listen 80;
 
     server_name api;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
