### PR TITLE
Add local overrides for xdebug for php based containers

### DIFF
--- a/packages/EasyDocker/templates/docker-compose.local.yml.twig
+++ b/packages/EasyDocker/templates/docker-compose.local.yml.twig
@@ -6,9 +6,24 @@ services:
       - ./:/var/www:delegated
       - ./docker/api/development/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini
 
+  artisan:
+    volumes:
+      - ./:/var/www:delegated
+      - ./docker/api/development/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini
+
+  composer:
+    volumes:
+      - ./:/var/www:delegated
+      - ./docker/api/development/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini
+
   cron:
     volumes:
       - ./:/var/www:delegated
+
+  migrate:
+    volumes:
+      - ./:/var/www:delegated
+      - ./docker/api/development/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini
 
   nginx:
     volumes:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | no

Adds overrides for development php.ini for all php based containers instead of just API
