### PR TITLE
Use custom token generator for auth0 jwt token creation

### DIFF
--- a/packages/EasyApiToken/src/External/Auth0JwtDriver.php
+++ b/packages/EasyApiToken/src/External/Auth0JwtDriver.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\EasyApiToken\External;
 
-use Auth0\SDK\API\Helpers\TokenGenerator;
 use Auth0\SDK\JWTVerifier;
 use LoyaltyCorp\EasyApiToken\External\Interfaces\JwtDriverInterface;
+use LoyaltyCorp\EasyApiToken\Helpers\Jwt\TokenGenerator;
 
 final class Auth0JwtDriver implements JwtDriverInterface
 {
@@ -92,7 +92,10 @@ final class Auth0JwtDriver implements JwtDriverInterface
 
         $generator = new TokenGenerator($this->audienceForEncode, $privateKey);
 
-        return $generator->generate($input['scopes'] ?? [], $input['lifetime'] ?? TokenGenerator::DEFAULT_LIFETIME);
+        return $generator->generate(
+            $input['scopes'] ?? [],
+            $input['subject'] ?? null,
+            $input['lifetime'] ?? null);
     }
 }
 

--- a/packages/EasyApiToken/src/External/Auth0JwtDriver.php
+++ b/packages/EasyApiToken/src/External/Auth0JwtDriver.php
@@ -94,7 +94,7 @@ final class Auth0JwtDriver implements JwtDriverInterface
 
         return $generator->generate(
             $input['scopes'] ?? [],
-            $input['subject'] ?? null,
+            $input['sub'] ?? null,
             $input['lifetime'] ?? null);
     }
 }

--- a/packages/EasyApiToken/src/Helpers/Jwt/TokenGenerator.php
+++ b/packages/EasyApiToken/src/Helpers/Jwt/TokenGenerator.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Helpers\Jwt;
+
+use Firebase\JWT\JWT;
+use LoyaltyCorp\EasyApiToken\Interfaces\Helpers\Jwt\TokenGeneratorInterface;
+
+class TokenGenerator implements TokenGeneratorInterface
+{
+    /**
+     * Default token expiration time.
+     */
+    private const DEFAULT_LIFETIME = 3600;
+
+    /**
+     * Audience for the ID token.
+     *
+     * @var string|null
+     */
+    private $audience;
+
+    /**
+     * Secret used to encode the token.
+     *
+     * @var string|null
+     */
+    private $secret;
+
+    /**
+     * TokenGenerator constructor.
+     *
+     * @param string|null $audience ID token audience to set.
+     * @param string|null $secret Token encryption secret to encode the token.
+     */
+    public function __construct(?string $audience = null, ?string $secret = null)
+    {
+        $this->audience = $audience;
+        $this->secret = $secret;
+    }
+
+    /**
+     * Create the ID token.
+     *
+     * @param mixed[] $scopes Array of scopes to include.
+     * @param string|null  $subject Information about JWT subject.
+     * @param integer|null $lifetime Lifetime of the token, in seconds.
+     * @param boolean|null $secretEncoded True to base64 decode the client secret.
+     *
+     * @return string
+     */
+    public function generate(
+        array $scopes,
+        ?string $subject = null,
+        ?int $lifetime = null,
+        ?bool $secretEncoded = null
+    ): string {
+        $secretEncoded = $secretEncoded ?? true;
+        $lifetime = $lifetime ?? self::DEFAULT_LIFETIME;
+        $time = time();
+        $payload = [
+            'iat' => $time,
+            'scopes' => $scopes,
+            'exp' => $time + $lifetime,
+            'aud' => $this->audience
+        ];
+
+        if ($subject !== null) {
+            $payload = \array_merge($payload, ['sub' => $subject]);
+        }
+
+        $payload['jti'] = md5(\json_encode($payload));
+
+        $secret = $secretEncoded ? base64_decode(strtr($this->secret, '-_', '+/')) : $this->secret;
+
+        return JWT::encode($payload, $secret);
+    }
+}

--- a/packages/EasyApiToken/src/Helpers/Jwt/TokenGenerator.php
+++ b/packages/EasyApiToken/src/Helpers/Jwt/TokenGenerator.php
@@ -71,7 +71,7 @@ class TokenGenerator implements TokenGeneratorInterface
 
         $payload['jti'] = md5(\json_encode($payload));
 
-        $secret = $secretEncoded ? base64_decode(strtr($this->secret, '-_', '+/')) : $this->secret;
+        $secret = $secretEncoded === true ? base64_decode(strtr($this->secret, '-_', '+/')) : $this->secret;
 
         return JWT::encode($payload, $secret);
     }

--- a/packages/EasyApiToken/src/Interfaces/Helpers/Jwt/TokenGeneratorInterface.php
+++ b/packages/EasyApiToken/src/Interfaces/Helpers/Jwt/TokenGeneratorInterface.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\EasyApiToken\Interfaces\Helpers\Jwt;
+
+interface TokenGeneratorInterface
+{
+    /**
+     * Create the ID token.
+     *
+     * @param mixed[] $scopes Array of scopes to include.
+     * @param string|null  $subject Information about JWT subject.
+     * @param integer|null $lifetime Lifetime of the token, in seconds.
+     * @param boolean|null $secretEncoded True to base64 decode the client secret.
+     *
+     * @return string
+     */
+    public function generate(
+        array $scopes,
+        ?string $subject = null,
+        ?int $lifetime = null,
+        ?bool $secretEncoded = null
+    ): string;
+}


### PR DESCRIPTION
There is a possible bug in Auth0 `TokenGenerator` where it does not allow us to add
`sub` (subject) claim.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Features and deprecations must be submitted against the master branch.
-->
