### PR TITLE
[EasyDecision] Reverse priority order for decision rules

### DIFF
--- a/packages/EasyDecision/readme.md
+++ b/packages/EasyDecision/readme.md
@@ -15,7 +15,7 @@
 - [x] affirmative: Yes as soon as first rule says yes
 - [x] consensus: Yes if more yes than no
 - [x] unanimous: Yes if everybody says yes
-- [x] Priority on rules: Run first the rules with biggest priority
+- [x] Priority on rules: Run first the rules with smallest priority
 - [x] Rules can say if they support the given input
 - [x] After run users can get which rules ran, their body and output
 - [x] Test the Laravel Decision Factory

--- a/packages/EasyDecision/src/Decisions/AbstractDecision.php
+++ b/packages/EasyDecision/src/Decisions/AbstractDecision.php
@@ -193,7 +193,7 @@ abstract class AbstractDecision implements DecisionInterface
     }
 
     /**
-     * Get sorted rules.
+     * Get sorted rules (priority value 0 is higher than 100).
      *
      * @param \LoyaltyCorp\EasyDecision\Interfaces\ContextInterface $context
      *
@@ -203,8 +203,8 @@ abstract class AbstractDecision implements DecisionInterface
     {
         // Sort rules by priority
         $rules = $this->rules;
-        \usort($rules, function (RuleInterface $first, RuleInterface $second): bool {
-            return $first->getPriority() < $second->getPriority();
+        \usort($rules, function (RuleInterface $first, RuleInterface $second): int {
+            return $first->getPriority() <=> $second->getPriority();
         });
 
         foreach ($rules as $rule) {

--- a/packages/EasyDecision/tests/Decisions/AffirmativeDecisionTest.php
+++ b/packages/EasyDecision/tests/Decisions/AffirmativeDecisionTest.php
@@ -81,15 +81,15 @@ final class AffirmativeDecisionTest extends AbstractTestCase
     }
 
     /**
-     * Decision should return true and run highest priority first.
+     * Decision should return true and run highest priority first (0 is higher than 100).
      *
      * @return void
      */
     public function testReturnTrueWithPriorities(): void
     {
         $decision = (new AffirmativeDecision())->addRules([
-            $this->createFalseRule('false-1'),
-            $this->createTrueRule('true-1', 100)
+            $this->createFalseRule('false-1', 100),
+            $this->createTrueRule('true-1')
         ]);
 
         $expected = [


### PR DESCRIPTION
[EasyDecision] Reverse priority order for decision rules (0 is now higher than 100)