### PR TITLE
[EasyDocker] Use .easy directory for easy-docker generated parameter & manifest files

### DIFF
--- a/packages/EasyDocker/src/Parameters/ParameterResolver.php
+++ b/packages/EasyDocker/src/Parameters/ParameterResolver.php
@@ -105,6 +105,6 @@ final class ParameterResolver implements ParameterResolverInterface
             $params = Yaml::parseFile($this->cacheFile);
         }
 
-        return $params + $this->parameterProvider->provide();
+        return $params ?? [] + $this->parameterProvider->provide();
     }
 }

--- a/packages/EasyDocker/tests/AbstractTestCase.php
+++ b/packages/EasyDocker/tests/AbstractTestCase.php
@@ -72,6 +72,18 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
+     * Create the temporary directory
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->getFilesystem()->mkdir(static::$cwd);
+    }
+
+    /**
      * Remove tmp dir.
      *
      * @return void

--- a/packages/EasyDocker/tests/Console/Commands/DockerFilesGeneratorCommandTest.php
+++ b/packages/EasyDocker/tests/Console/Commands/DockerFilesGeneratorCommandTest.php
@@ -8,6 +8,37 @@ use LoyaltyCorp\EasyDocker\Tests\AbstractTestCase;
 final class DockerFilesGeneratorCommandTest extends AbstractTestCase
 {
     /**
+     * Ensure the .easy directory is only used if no existing files are present
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function testEasyDirectoryBackwardsCompatibility(): void
+    {
+        $inputs = [
+            'project',
+            'true',
+            'true',
+            'true'
+        ];
+
+        $filesNotExisting = [
+            '.easy/easy-docker-manifest.json',
+            '.easy/easy-docker-params.yaml',
+        ];
+
+        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-docker-manifest.json', '{}');
+        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-docker-params.yaml');
+
+        $this->executeCommand('generate', $inputs);
+
+        foreach ($filesNotExisting as $file) {
+            self::assertFalse($this->getFilesystem()->exists(static::$cwd . '/' . $file));
+        }
+    }
+
+    /**
      * Command should generate cloudformation files.
      *
      * @return void
@@ -24,6 +55,8 @@ final class DockerFilesGeneratorCommandTest extends AbstractTestCase
         ];
 
         $files = [
+            '.easy/easy-docker-manifest.json',
+            '.easy/easy-docker-params.yaml',
             'docker/api/cron/crontab',
             'docker/api/development/php.ini',
             'docker/api/development/php-composer.ini',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

By default, a `.easy` directory will be assumed for parameter and manifest files generated by this tool
Backwards compatibility is present, this will only affect new projects using the tool, when a manifest/params file does not already exist