### PR TITLE
[EasyCfhighlander] Use .easy directory for easy-docker generated parameter & manifest files

### DIFF
--- a/packages/EasyCfhighlander/src/Console/Commands/AbstractTemplatesCommand.php
+++ b/packages/EasyCfhighlander/src/Console/Commands/AbstractTemplatesCommand.php
@@ -392,8 +392,8 @@ abstract class AbstractTemplatesCommand extends Command
      */
     private function getEasyDirectory(string $cwd): string
     {
-        // If easy-docker* file already exists in cwd, .easy directory will not be used/created
-        if (\file_exists($cwd . \DIRECTORY_SEPARATOR . 'easy-docker-params.yaml') === true) {
+        // If easy-cfhighlander* file already exists in cwd, .easy directory will not be used/created
+        if (\file_exists($cwd . \DIRECTORY_SEPARATOR . 'easy-cfhighlander-params.yaml') === true) {
             return $cwd;
         }
 

--- a/packages/EasyCfhighlander/src/Parameters/ParameterResolver.php
+++ b/packages/EasyCfhighlander/src/Parameters/ParameterResolver.php
@@ -135,6 +135,6 @@ final class ParameterResolver implements ParameterResolverInterface
             $params = Yaml::parseFile($this->cacheFile);
         }
 
-        return $params + $this->parameterProvider->provide();
+        return $params ?? [] + $this->parameterProvider->provide();
     }
 }

--- a/packages/EasyCfhighlander/tests/Console/Commands/CloudFormationCommandTest.php
+++ b/packages/EasyCfhighlander/tests/Console/Commands/CloudFormationCommandTest.php
@@ -31,17 +31,20 @@ final class CloudFormationCommandTest extends AbstractTestCase
         ];
 
         $filesNotExisting = [
-            '.easy/easy-docker-manifest.json',
-            '.easy/easy-docker-params.yaml',
+            '.easy/easy-cfhighlander-manifest.json',
+            '.easy/easy-cfhighlander-params.yaml',
         ];
 
-        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-docker-manifest.json', '{}');
-        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-docker-params.yaml');
+        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-cfhighlander-manifest.json', '{}');
+        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-cfhighlander-params.yaml');
 
         $this->executeCommand('code', $inputs);
 
         foreach ($filesNotExisting as $file) {
-            self::assertFalse($this->getFilesystem()->exists(static::$cwd . '/' . $file));
+            self::assertFalse(
+                $this->getFilesystem()->exists(static::$cwd . '/' . $file),
+                \sprintf('%s exists, but was not expected to', $file)
+            );
         }
     }
 

--- a/packages/EasyCfhighlander/tests/Console/Commands/CloudFormationCommandTest.php
+++ b/packages/EasyCfhighlander/tests/Console/Commands/CloudFormationCommandTest.php
@@ -8,6 +8,44 @@ use LoyaltyCorp\EasyCfhighlander\Tests\AbstractTestCase;
 final class CloudFormationCommandTest extends AbstractTestCase
 {
     /**
+     * Ensure the .easy directory is only used if no existing files are present
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function testEasyDirectoryBackwardsCompatibility(): void
+    {
+        $inputs = [
+            'project', // project
+            'projectDatabase', // db_name
+            'projectDatabaseUsername', // db_username
+            'project.com', // dns_domain
+            'true', // redis_enabled,
+            'true', // elasticsearch_enabled
+            'project', // ssm_prefix
+            'project', // sqs_queue
+            'aws_dev_account', // dev_account
+            '599070804856', // ops_account
+            'aws_prod_account' // prod_account
+        ];
+
+        $filesNotExisting = [
+            '.easy/easy-docker-manifest.json',
+            '.easy/easy-docker-params.yaml',
+        ];
+
+        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-docker-manifest.json', '{}');
+        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-docker-params.yaml');
+
+        $this->executeCommand('code', $inputs);
+
+        foreach ($filesNotExisting as $file) {
+            self::assertFalse($this->getFilesystem()->exists(static::$cwd . '/' . $file));
+        }
+    }
+
+    /**
      * Command should generate cloudformation files.
      *
      * @return void

--- a/packages/EasyCfhighlander/tests/Console/Commands/CodeCommandTest.php
+++ b/packages/EasyCfhighlander/tests/Console/Commands/CodeCommandTest.php
@@ -8,6 +8,44 @@ use LoyaltyCorp\EasyCfhighlander\Tests\AbstractTestCase;
 final class CodeCommandTest extends AbstractTestCase
 {
     /**
+     * Ensure the .easy directory is only used if no existing files are present
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function testEasyDirectoryBackwardsCompatibility(): void
+    {
+        $inputs = [
+            'project', // project
+            'projectDatabase', // db_name
+            'projectDatabaseUsername', // db_username
+            'project.com', // dns_domain
+            'true', // redis_enabled,
+            'true', // elasticsearch_enabled
+            'project', // ssm_prefix
+            'project', // sqs_queue
+            'aws_dev_account', // dev_account
+            '599070804856', // ops_account
+            'aws_prod_account' // prod_account
+        ];
+
+        $filesNotExisting = [
+            '.easy/easy-docker-manifest.json',
+            '.easy/easy-docker-params.yaml',
+        ];
+
+        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-docker-manifest.json', '{}');
+        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-docker-params.yaml');
+
+        $this->executeCommand('code', $inputs);
+
+        foreach ($filesNotExisting as $file) {
+            self::assertFalse($this->getFilesystem()->exists(static::$cwd . '/' . $file));
+        }
+    }
+
+    /**
      * Command should generate cloudformation files.
      *
      * @return void

--- a/packages/EasyCfhighlander/tests/Console/Commands/CodeCommandTest.php
+++ b/packages/EasyCfhighlander/tests/Console/Commands/CodeCommandTest.php
@@ -31,12 +31,12 @@ final class CodeCommandTest extends AbstractTestCase
         ];
 
         $filesNotExisting = [
-            '.easy/easy-docker-manifest.json',
-            '.easy/easy-docker-params.yaml',
+            '.easy/easy-cfhighlander-manifest.json',
+            '.easy/easy-cfhighlander-params.yaml',
         ];
 
-        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-docker-manifest.json', '{}');
-        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-docker-params.yaml');
+        $this->getFilesystem()->dumpFile(static::$cwd . '/' . 'easy-cfhighlander-manifest.json', '{}');
+        $this->getFilesystem()->touch(static::$cwd . '/' . 'easy-cfhighlander-params.yaml');
 
         $this->executeCommand('code', $inputs);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

Same as https://github.com/loyaltycorp/easy-monorepo/pull/68 but for EasyCfhighlander

> By default, a `.easy` directory will be assumed for parameter and manifest files generated by this tool
> Backwards compatibility is present, this will only affect new projects using the tool, when a manifest/params file does not already exist