### PR TITLE
Updated GitHub PR Template to denote CHANGELOG does not actually require

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 | Q             | A
 | ------------- | ---
 | Bug fix?      | yes/no
-| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
+| New feature?  | yes/no <!-- Do not update CHANGELOG.md, this will be generated -->
 | BC breaks?    | no     <!-- see https://symfony.com/bc -->
 | Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
 | Tests pass?   | yes    <!-- please add some, will be required by reviewers -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 

The template for submitting a new PR mentioned the CHANGELOG should be updated, however this is not the case, as it is handled automatically
