### PR TITLE
updated Auth0JwtDriver to be able to accept a string scope.

### DIFF
--- a/packages/EasyApiToken/src/External/Auth0/Interfaces/TokenGeneratorInterface.php
+++ b/packages/EasyApiToken/src/External/Auth0/Interfaces/TokenGeneratorInterface.php
@@ -8,7 +8,7 @@ interface TokenGeneratorInterface
     /**
      * Create the ID token.
      *
-     * @param mixed[] $scopes Array of scopes to include.
+     * @param string $scope Space separated list of scopes.
      * @param string|null  $subject Information about JWT subject.
      * @param integer|null $lifetime Lifetime of the token, in seconds.
      * @param boolean|null $secretEncoded True to base64 decode the client secret.
@@ -16,7 +16,7 @@ interface TokenGeneratorInterface
      * @return string
      */
     public function generate(
-        array $scopes,
+        string $scope,
         ?string $subject = null,
         ?int $lifetime = null,
         ?bool $secretEncoded = null

--- a/packages/EasyApiToken/src/External/Auth0/TokenGenerator.php
+++ b/packages/EasyApiToken/src/External/Auth0/TokenGenerator.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\EasyApiToken\External\Auth0;
 
+use Auth0\SDK\API\Helpers\TokenGenerator as BaseTokenGenerator;
 use Firebase\JWT\JWT;
 use LoyaltyCorp\EasyApiToken\External\Auth0\Interfaces\TokenGeneratorInterface;
-use Auth0\SDK\API\Helpers\TokenGenerator as BaseTokenGenerator;
 
 final class TokenGenerator implements TokenGeneratorInterface
 {
@@ -38,15 +38,15 @@ final class TokenGenerator implements TokenGeneratorInterface
     /**
      * Create the ID token.
      *
-     * @param mixed[] $scopes Array of scopes to include.
-     * @param string|null  $subject Information about JWT subject.
+     * @param string|null $scope Space separated list of scopes.
+     * @param string|null $subject Information about JWT subject.
      * @param integer|null $lifetime Lifetime of the token, in seconds.
      * @param boolean|null $secretEncoded True to base64 decode the client secret.
      *
      * @return string
      */
     public function generate(
-        array $scopes,
+        ?string $scope,
         ?string $subject = null,
         ?int $lifetime = null,
         ?bool $secretEncoded = null
@@ -57,10 +57,13 @@ final class TokenGenerator implements TokenGeneratorInterface
         $time = \time();
         $payload = [
             'iat' => $time,
-            'scopes' => $scopes,
             'exp' => $time + $lifetime,
             'aud' => $this->audience
         ];
+
+        if (\is_string($scope) === true) {
+            $payload['scope'] = $scope;
+        }
 
         if ($subject !== null) {
             $payload['sub'] = $subject;

--- a/packages/EasyApiToken/src/External/Auth0JwtDriver.php
+++ b/packages/EasyApiToken/src/External/Auth0JwtDriver.php
@@ -93,7 +93,7 @@ final class Auth0JwtDriver implements JwtDriverInterface
         $generator = new TokenGenerator($this->audienceForEncode, $privateKey);
 
         return $generator->generate(
-            $input['scopes'] ?? [],
+            $input['scope'] ?? null,
             $input['sub'] ?? null,
             $input['lifetime'] ?? null);
     }

--- a/packages/EasyApiToken/tests/AbstractAuth0JwtTokenTestCase.php
+++ b/packages/EasyApiToken/tests/AbstractAuth0JwtTokenTestCase.php
@@ -22,7 +22,7 @@ abstract class AbstractAuth0JwtTokenTestCase extends AbstractJwtTokenTestCase
      * @var mixed[]
      */
     protected static $tokenPayload = [
-        'scopes' => [],
+        'scope' => 'purple orange',
         'aud' => 'my-identifier'
     ];
 
@@ -61,11 +61,14 @@ abstract class AbstractAuth0JwtTokenTestCase extends AbstractJwtTokenTestCase
     /**
      * Create JWT token for given algo.
      *
+     * @param mixed[]|null $input
+     *
      * @return string
      */
-    protected function createToken(): string
+    protected function createToken(?array $input = null): string
     {
-        return $this->createAuth0JwtDriver(null, null, static::$key)->encode([]);
+        $input = $input ?? [];
+        return $this->createAuth0JwtDriver(null, null, static::$key)->encode($input);
     }
 }
 

--- a/packages/EasyApiToken/tests/Decoders/Auth0JwtTokenDecoderTest.php
+++ b/packages/EasyApiToken/tests/Decoders/Auth0JwtTokenDecoderTest.php
@@ -23,7 +23,7 @@ final class Auth0JwtTokenDecoderTest extends AbstractAuth0JwtTokenTestCase
 
         /** @var \LoyaltyCorp\EasyApiToken\Interfaces\Tokens\JwtEasyApiTokenInterface $token */
         $token = (new JwtTokenDecoder($jwtEasyApiTokenFactory))->decode($this->createServerRequest([
-            'HTTP_AUTHORIZATION' => 'Bearer ' . $this->createToken()
+            'HTTP_AUTHORIZATION' => 'Bearer ' . $this->createToken(['scope' => 'purple orange'])
         ]));
 
         $payload = $token->getPayload();

--- a/packages/EasyApiToken/tests/Decoders/Auth0JwtTokenInQueryDecoderTest.php
+++ b/packages/EasyApiToken/tests/Decoders/Auth0JwtTokenInQueryDecoderTest.php
@@ -23,7 +23,7 @@ final class Auth0JwtTokenInQueryDecoderTest extends AbstractAuth0JwtTokenTestCas
         $decoder = new JwtTokenInQueryDecoder($jwtEasyApiTokenFactory, 'param');
 
         $request = $this->createServerRequest(null, [
-            'param' => $this->createToken()
+            'param' => $this->createToken(['scope' => 'purple orange'])
         ]);
 
         /** @var \LoyaltyCorp\EasyApiToken\Interfaces\Tokens\JwtEasyApiTokenInterface $token */

--- a/packages/EasyApiToken/tests/Encoders/Auth0JwtTokenEncoderTest.php
+++ b/packages/EasyApiToken/tests/Encoders/Auth0JwtTokenEncoderTest.php
@@ -26,7 +26,7 @@ final class Auth0JwtTokenEncoderTest extends AbstractAuth0JwtTokenTestCase
     {
         $jwtDriver = $this->createAuth0JwtDriver();
 
-        $tokenString = (new JwtTokenEncoder($jwtDriver))->encode(new JwtEasyApiToken([]));
+        $tokenString = (new JwtTokenEncoder($jwtDriver))->encode(new JwtEasyApiToken(['scope' => 'purple orange']));
         /** @var \LoyaltyCorp\EasyApiToken\Interfaces\Tokens\JwtEasyApiTokenInterface $token */
         $token = $this->createJwtTokenDecoder()->decode($this->createServerRequest([
             'HTTP_AUTHORIZATION' => 'Bearer ' . $tokenString
@@ -59,6 +59,7 @@ final class Auth0JwtTokenEncoderTest extends AbstractAuth0JwtTokenTestCase
 
     /**
      * JwtTokenEncoder should throw an exception if anything goes wrong while encoding token.
+     * In this case passing a scope as an array, when it should actually be a string
      *
      * @return void
      *
@@ -71,7 +72,7 @@ final class Auth0JwtTokenEncoderTest extends AbstractAuth0JwtTokenTestCase
 
         $jwtDriver = $this->createAuth0JwtDriver();
 
-        (new JwtTokenEncoder($jwtDriver))->encode(new JwtEasyApiToken(['scopes' => 1]));
+        (new JwtTokenEncoder($jwtDriver))->encode(new JwtEasyApiToken(['scope' => []]));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | maybe     <!-- see https://symfony.com/bc -->
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | PYMT-1157

<!--
A decoded JWT token contains scope as a space separated string. This fixed the `Auth0JwtDriver` to be able to accept a string scope.
-->

As for BC breaks, `Subscriptions` will be updated right away after this gets approved to be able to understand a string scope.

A decoded JWT with scopes looks like this

`{ "iss": "https://eonx-dev.au.auth0.com/", "sub": "auth0|5d6c5acdd606bc0d5d8323c4", "aud": "https://api.dev.payments.eonx.com/", "iat": 1567465645, "exp": 1567552045, "azp": "0dZCbpnN7DTrLzhYRaKpoeWvlc2H47KX", "scope": "operator read:payments", "permissions": [ "operator", "read:payments", "write:payments" ] }`