### PR TITLE
[EasyEntityChange] Preserving entity id for use at postFlush

### DIFF
--- a/packages/EasyEntityChange/src/Doctrine/EntityChangeSubscriber.php
+++ b/packages/EasyEntityChange/src/Doctrine/EntityChangeSubscriber.php
@@ -88,7 +88,7 @@ final class EntityChangeSubscriber implements EventSubscriber
         }
 
         foreach ($unitOfWork->getScheduledEntityDeletions() as $entity) {
-            $this->flagForDelete($entity);
+            $this->flagForDelete(clone $entity);
         }
 
         foreach ($unitOfWork->getScheduledCollectionUpdates() as $collection) {


### PR DESCRIPTION
- [EasyEntityChange] Preserving entity id for use at postFlush by using entity clone

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes <!-- Do not update CHANGELOG.md, this will be generated -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Features and deprecations must be submitted against the master branch.
-->
